### PR TITLE
Update __init__.py

### DIFF
--- a/library/microdotphat/__init__.py
+++ b/library/microdotphat/__init__.py
@@ -27,7 +27,7 @@ _n3 = NanoMatrix(address=0x61)
 
 _mat = [(_n1, 1), (_n1, 0), (_n2, 1), (_n2, 0), (_n3, 1), (_n3, 0)]
 
-WIDTH = 45
+WIDTH = 48
 HEIGHT = 7
 
 _buf = numpy.zeros((HEIGHT,WIDTH))
@@ -52,7 +52,7 @@ def clear():
 
     global _buf, _decimal
     _decimal = [0] * 6
-    _buf.fill(0)
+    _buf = numpy.zeros((HEIGHT,WIDTH))
 
 def fill(c):
     """Fill the buffer either lit or unlit


### PR DESCRIPTION
Change 1) Existing default buffer width (45) includes padding (3 columns) between each array of 5 columns but does not include 3 padding columns at the end. This causes scroll issues when horizontally scrolling characters by whole blocks (8 columns) at a time as the characters wrapping around end to end do not do so by whole blacks whereas the characters in the middle do move by one whole block.
Change 2) The clear function does not also resize the buffer but only fills it with zeros. Thus the buffer can never get smaller. Modified to use the same command as used in the original initalisation of the module which also resets the buffer size to the default size.