### PR TITLE
Add fallback to SMBus2, add is_connected() method to microdotphat and NanoMatrix 

### DIFF
--- a/library/microdotphat/__init__.py
+++ b/library/microdotphat/__init__.py
@@ -61,6 +61,14 @@ def fill(c):
     global _buf
     _buf.fill(c)
 
+
+def is_connected():
+    """ Check if a microdot pHat is connected by trying to reach it over I2C.
+    Returns True if detected, False if not detected.
+    """
+    return NanoMatrix.is_connected(0x61) and NanoMatrix.is_connected(0x62) and NanoMatrix.is_connected(0x63)
+
+
 def set_clear_on_exit(value):
     """Set whether the display should be cleared on exit
 

--- a/library/microdotphat/matrix.py
+++ b/library/microdotphat/matrix.py
@@ -1,16 +1,7 @@
-from sys import exit, version_info
-
-
 try:
-    from smbus import SMBus
-except ImportError as e:
-    try:
-        from smbus2 import SMBus
-    except ImportError as e2:
-        if version_info[0] < 3:
-            exit("This library requires python-smbus or smbus2\nInstall with: sudo apt-get install python-smbus")
-        elif version_info[0] == 3:
-            exit("This library requires python3-smbus or smbus2\nInstall with: sudo apt-get install python3-smbus")
+    from smbus2 import SMBus
+except ImportError:
+    raise RuntimeError("This library requires smbus2\nInstall with: pip install smbus2")
 
 
 ADDR = 0x61

--- a/library/microdotphat/matrix.py
+++ b/library/microdotphat/matrix.py
@@ -1,12 +1,16 @@
 from sys import exit, version_info
 
+
 try:
-    import smbus
-except ImportError:
-    if version_info[0] < 3:
-        exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
-    elif version_info[0] == 3:
-        exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
+    from smbus import SMBus
+except ImportError as e:
+    try:
+        from smbus2 import SMBus
+    except ImportError as e2:
+        if version_info[0] < 3:
+            exit("This library requires python-smbus or smbus2\nInstall with: sudo apt-get install python-smbus")
+        elif version_info[0] == 3:
+            exit("This library requires python3-smbus or smbus2\nInstall with: sudo apt-get install python3-smbus")
 
 
 ADDR = 0x61
@@ -58,7 +62,7 @@ class NanoMatrix:
         self.address = address
         self._brightness = 127
 
-        self.bus = smbus.SMBus(1)
+        self.bus = SMBus(1)
 
         self.bus.write_byte_data(self.address, CMD_MODE, MODE)
         self.bus.write_byte_data(self.address, CMD_OPTIONS, OPTS)
@@ -66,6 +70,15 @@ class NanoMatrix:
 
         self._BUF_MATRIX_1 = [0] * 8
         self._BUF_MATRIX_2 = [0] * 8
+
+    @staticmethod
+    def is_connected(address=0x61):
+        bus = SMBus(1)
+        try:
+            bus.write_byte(address, 0)
+            return True
+        except:  # exception if write_byte fails, meaning the device isn't connected
+            return False
 
     def set_brightness(self, brightness):
         self._brightness = int(brightness * 127)
@@ -77,7 +90,7 @@ class NanoMatrix:
 
         if m == MATRIX_1:
            if c == 1:
-               self._BUF_MATRIX_1[6] |= 0b10000000    
+               self._BUF_MATRIX_1[6] |= 0b10000000
            else:
                self._BUF_MATRIX_1[6] &= 0b01111111
 


### PR DESCRIPTION
This PR adds a fallback to SMBus2, as well as a new is_connected() method.

is_connected() checks if the microdotphat is connected by trying to write a byte to it. It is useful for projects where you want to enable/disable output to the display based on the presence of the module, or if you just want to test the wiring of your project. I believe it is a good addition to the library. Let me know if you do not believe it fits the library, or if you'd like to see changes to the proposed code.

Regards,
Bert